### PR TITLE
allow specification of goals relative to the robot

### DIFF
--- a/motion_planning_libraries.orogen
+++ b/motion_planning_libraries.orogen
@@ -50,6 +50,9 @@ task_context "Task" do
         
     input_port('goal_pose_samples', 'base/samples/RigidBodyState').
         doc("Goal pose in the world, using x and y and yaw. If the start state port is not connected this port will be used.")
+    input_port('goal_pose_rel_samples', 'base/samples/RigidBodyState').
+            doc("Goal pose in the robot frame, using x and y and yaw. If the start state port is not connected this port will be used.")
+
         
     output_port('waypoints', '/std/vector<base::Waypoint>').
         doc "Waypoint list."

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -119,6 +119,15 @@ void Task::updateHook()
                 _goal_pose_samples_debug.write(mGoalPose);
             }
         }
+        if(_goal_pose_rel_samples.readNewest(mGoalPose) == RTT::NewData) {
+            Eigen::Affine3d t_rel = mGoalPose.getTransform();
+            Eigen::Affine3d t_cur = mStartPose.getTransform();
+            Eigen::Affine3d t_world = t_cur*t_rel;
+            mGoalPose.setTransform(t_world);
+            if(mpMotionPlanningLibraries->setGoalState(State(mGoalPose))) {
+                _goal_pose_samples_debug.write(mGoalPose);
+            }
+        }
     }
     
     mpMotionPlanningLibraries->allInputsAvailable(err_inputs);


### PR DESCRIPTION
Additional input port is added, that allows to pass a goal pose relative to the the robot is currently. From relative pose input, the absolute goal pose is calculated which is then passed to the planner library.